### PR TITLE
Enabling autoupdate

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,13 @@ ENV	REGION=3 \
 	STARTMAP="de_dust" \
 	TICKRATE=64
 
+# For whatever reason, the original 'srcds_run' file is broken. It's using "steam.sh" instead of "steamcmd.sh"
+RUN sed -i 's/steam.sh/steamcmd.sh/g' /home/cs/csgo_server/srcds_run
+
+# Create the autoupdate script which is triggered when the round ends
+RUN echo 'login anonymous\nforce_install_dir /home/cs/csgo_server/\napp_update 740 validate\nquit' >> /home/cs/autoupdate.sh \
+    chmod +x /home/cs/autoupdate.sh
+
 COPY ./entrypoint.sh /
 COPY ./server.cfg.template /
 ENTRYPOINT ["sh", "/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,4 +15,7 @@ su cs -c '/home/cs/csgo_server/srcds_run\
 	-game csgo\
 	-maxplayers_override $MAXPLAYERS\
 	-net_port_try 1\
-	-tickrate $TICKRATE'
+	-tickrate $TICKRATE \
+	-autoupdate \
+	-steamcmd_script /home/cs/autoupdate.sh \
+	-steam_dir /home/cs'


### PR DESCRIPTION
If there is an CS:Go update available, the server will:
- wait untill the current game is over
OR
- check if the server is idle
before installing the update and restarting the game.
The script used to update the game is created within the Dockerfile.

Important: The srcds_run is broken at the moment, so we are repairing it by an simple RUN sed -i 's/steam.sh/steamcmd.sh/g' /home/cs/csgo_server/srcds_run